### PR TITLE
update json gem to version 1.7.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'http://rubygems.org'
 gem 'sinatra'
 gem 'neography'
 gem 'haml'
-gem 'json'
+gem 'json', '~> 1.7.7'
 
 group :test do
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GEM
     haml (3.1.4)
     httparty (0.7.8)
       crack (= 0.1.8)
-    json (1.6.4)
+    json (1.7.7)
     neography (0.0.20)
       httparty (~> 0.7.8)
       json
@@ -41,7 +41,7 @@ PLATFORMS
 
 DEPENDENCIES
   haml
-  json
+  json (~> 1.7.7)
   neography
   net-http-spy
   rack-test


### PR DESCRIPTION
This update is required to use neovigator with ruby 2.0.0.

Great tool, thanks!!
